### PR TITLE
remove dependency on "util" so the library can be used in non-node environments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var util = require('util');
 var DEFAULT_DELIMITER = ',';
 
 function unescape(string) {
@@ -22,12 +21,12 @@ function parse(string, config) {
   var delimiter = config.delimiter || DEFAULT_DELIMITER;
 
   if (delimiter.length !== 1) {
-    throw new Error(util.format('Invalid delimiter "%s"', delimiter));
+    throw new Error('Invalid delimiter "' + delimiter + '"');
   }
 
   var type = typeof string;
   if (type !== 'string') {
-    throw new Error(util.format('Expected a string instead of %s', type));
+    throw new Error('Expected a string instead of ' + type);
   }
 
   string = string.trim();
@@ -52,7 +51,7 @@ function parse(string, config) {
     }
     var result = string.substring(start, idx);
     if (string[idx] !== quote) {
-      throw new Error(util.format('Unclosed literal "%s"', result));
+      throw new Error('Unclosed literal "' + result + '"');
     }
     idx += 1; // skip quote
     return unescape(result);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stringlist",
   "version": "0.0.4",
   "description": "Parses lists of strings into array.",
-  "main": "lib",
+  "main": "lib/index.js",
   "scripts": {
     "test": "npm run lint && npm run mocha",
     "mocha": "mocha ./test",


### PR DESCRIPTION
remove dependency on "util" so it can be used in non-node environments

\+ make "main" explicit to unconfuse Firefox:

https://bugzilla.mozilla.org/show_bug.cgi?id=1168238
